### PR TITLE
fix: Adjust left margin on narrow screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,10 +1,24 @@
 
 body {
-  margin-left: 10em;
-  margin-top: 5em;
-  width: 45em;
+  margin-left: 2em;
+  margin-top: 2em;
+  max-width: 45em;
   font-family: helvetica, arial, sans-serif;
   font-size: 14px;
+}
+
+@media only screen and (min-device-width: 600px) and (max-device-width: 800px) {
+  body {
+    margin-left: 5em;
+    margin-top: 5em;
+  }
+}
+
+@media only screen and (min-device-width: 800px) {
+  body {
+    margin-left: 10em;
+    margin-top: 5em;
+  }
 }
 
 ul#social {


### PR DESCRIPTION
* Use media queries to make the left margin smaller on devices with
  small screens (such as phones).
* Use `max-width` instead of `width` for body so that the text wraps
  if it does not fit the screen.